### PR TITLE
Update publish-release.yml to commit release version to meta.json

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "Salesforce PubSub",
+  "name": "Salesforce Pub/Sub (Inbound)",
   "owner": "WSO2",
   "product": "MI",
   "mavenGroupId": "org.wso2.integration.inbound",
@@ -7,7 +7,7 @@
   "rank": 15,
   "type": "Inbound",
   "category": "Developer Tools",
-  "documentationUrl": "",
+  "documentationUrl": "https://mi.docs.wso2.com/en/latest/reference/connectors/sf-pubsub-inbound/sf-pubsub-inbound-endpoint-example/",
   "description": "Inbuilt Salesforce Pub/Sub Event Listener",
   "status": "Active",
   "labels": [

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,13 +1,9 @@
 name: Publish Release
-
 on:
   workflow_dispatch:
-
 jobs:
   Ubuntu:
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -24,6 +20,55 @@ jobs:
           VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml | sed 's/-SNAPSHOT$//')
           VERSION_TAG="v$VERSION"
           echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Update meta.json with new release
+        run: |
+          # Create a temporary script to update meta.json
+          cat > update_meta.py << 'EOF'
+          import json
+          import sys
+          import os
+          
+          # Read the current meta.json
+          with open('.connector-store/meta.json', 'r') as f:
+              data = json.load(f)
+          
+          # Get the new version tag from the environment
+          new_tag = os.environ['VERSION_TAG']
+          
+          # Check if this version already exists
+          existing_tags = [release['tagName'] for release in data['releases']]
+          if new_tag not in existing_tags:
+              # Add new release to the beginning of the releases array
+              new_release = {
+                  "tagName": new_tag,
+                  "products": ["MI 4.4.0"],
+                  "operations": [],
+                  "connections": [],
+                  "isHidden": False
+              }
+              data['releases'].insert(0, new_release)
+              
+              # Write back to file
+              with open('.connector-store/meta.json', 'w') as f:
+                  json.dump(data, f, indent=2)
+              
+              print(f"Added new release {new_tag} to meta.json")
+          else:
+              print(f"Release {new_tag} already exists in meta.json")
+          EOF
+          
+          # Run the Python script
+          python3 update_meta.py
+          
+          # Verify the change
+          echo "Updated meta.json content:"
+          cat .connector-store/meta.json
+      - name: Commit meta.json changes
+        run: |
+          git add .connector-store/meta.json
+          git commit -m "Add release ${{ env.VERSION_TAG }} to meta.json" || echo "No changes to commit"
+          git push origin main
       - name: Configure Maven settings file
         run: |
           mkdir -p ~/.m2
@@ -58,3 +103,4 @@ jobs:
             --title="${{ env.VERSION_TAG }}" \
             --generate-notes \
             target/*.zip
+            


### PR DESCRIPTION
## Purpose
> $Subject
- This fix applies to inbound endpoint repositories, assuming that the maintainers keep the latest versions updated in the meta.json.
- Improvements for connectors will be addressed later.
